### PR TITLE
Spelling of "opposite" was missing a p

### DIFF
--- a/notebooks/Workshop.ipynb
+++ b/notebooks/Workshop.ipynb
@@ -637,11 +637,11 @@
     "adjacent :: Integer\n",
     "adjacent = 3\n",
     "\n",
-    "oposite :: Integer\n",
-    "oposite = 4\n",
+    "opposite :: Integer\n",
+    "opposite = 4\n",
     "\n",
     "hypotenuse :: Integer\n",
-    "hypotenuse = sqrt (adjacent ** 2 + oposite ** 2)\n",
+    "hypotenuse = sqrt (adjacent ** 2 + opposite ** 2)\n",
     "\n",
     "case hypotenuse of 5 -> \"Maths!\""
    ]
@@ -787,7 +787,7 @@
    "outputs": [],
    "source": [
     "function squared x = x ** 2\n",
-    "function hypotenuse adjacent oposite = sqrt (squared adjacent + squared oposite)"
+    "function hypotenuse adjacent opposite = sqrt (squared adjacent + squared opposite)"
    ]
   },
   {


### PR DESCRIPTION
- quick search and replace of "oposite" with "opposite"