### PR TITLE
Use a different error on the tuples example

### DIFF
--- a/notebooks/Workshop.ipynb
+++ b/notebooks/Workshop.ipynb
@@ -427,7 +427,7 @@
     "y = \"another one\"\n",
     "z = (x,y)\n",
     "\n",
-    "wtf = (z, wtf)"
+    "wtf = (x, y z)"
    ]
   },
   {
@@ -435,7 +435,8 @@
    "metadata": {},
    "source": [
     "<span class=\"hint\">\n",
-    "    wtf is completely nonsensical.\n",
+    "    Members of tuples are separated by commas and enclosed in",
+    "    parentheses.\n",
     "</span>"
    ]
   },


### PR DESCRIPTION
Hi @sordina,

I thought of a way to improve the tuples example. The problem here is that we're seeing a recursive data structure that can't be well typed because the type would be infinite, before we've introduced recursive functions or data.  By using a different error we can avoid potential confusion (I think).

Hope this helps.